### PR TITLE
Improve API

### DIFF
--- a/src/main/scala/com/couchbase/spark/SparkContextFunctions.scala
+++ b/src/main/scala/com/couchbase/spark/SparkContextFunctions.scala
@@ -29,21 +29,17 @@ import org.apache.spark.SparkContext
 
 import scala.reflect.ClassTag
 
+import org.apache.spark.rdd.RDD
+
 class SparkContextFunctions(@transient val sc: SparkContext) extends Serializable {
 
-  def couchbaseGet[D <: Document[_]: ClassTag](id: String): DocumentRDD[D] = {
-    couchbaseGet(Seq(id)).asInstanceOf[DocumentRDD[D]]
+  def couchbaseGet[D <: Document[_]: ClassTag](ids: String*): RDD[D] = {
+    // Should ids be vararg or Seq?
+    sc.parallelize(ids).documents
   }
 
-  def couchbaseGet[D <: Document[_]](ids: Seq[String])(implicit ct: ClassTag[D]) = {
-    ct match {
-      case ClassTag.Nothing => new DocumentRDD[JsonDocument](sc, ids, 1)
-      case _ => new DocumentRDD[D](sc, ids, 1)
-    }
-  }
-
-  def couchbaseView(query: ViewQuery) = {
-    new ViewRDD(sc, query)
+  def couchbaseView(query: ViewQuery): ViewRDD = {
+    new ViewRDD(sc, query.getDesign, query.getView)
   }
 
 }

--- a/src/main/scala/com/couchbase/spark/connection/CouchbaseConfig.scala
+++ b/src/main/scala/com/couchbase/spark/connection/CouchbaseConfig.scala
@@ -32,6 +32,7 @@ object CouchbaseConfig {
   val DEFAULT_PASSWORD = ""
 
   def apply(cfg: SparkConf) = {
+    // Is it better to throw an exception if people forget to set the configs?
     val host = cfg.get("couchbase.host", DEFAULT_HOST)
     val bucket = cfg.get("couchbase.bucket", DEFAULT_BUCKET)
     val password = cfg.get("couchbase.password", DEFAULT_PASSWORD)

--- a/src/main/scala/com/couchbase/spark/rdd/ViewRDD.scala
+++ b/src/main/scala/com/couchbase/spark/rdd/ViewRDD.scala
@@ -3,24 +3,23 @@ package com.couchbase.spark.rdd
 import com.couchbase.client.java.document.Document
 import com.couchbase.client.java.view.{AsyncViewResult, AsyncViewRow, ViewQuery}
 import com.couchbase.spark.connection.{CouchbaseConnection, CouchbaseConfig}
+import com.couchbase.spark._
 import org.apache.spark.{TaskContext, Partition, SparkContext}
 import org.apache.spark.rdd.RDD
-import rx.Observable
-import rx.functions.Func1
-import rx.lang.scala.Observable
 
-import scala.collection.JavaConversions._
 import rx.lang.scala.JavaConversions._
 
 import scala.reflect.ClassTag
 
 case class CouchbaseViewRow(id: String, key: Any, value: Any)
 
-class ViewRDD(sc: SparkContext,viewQuery: ViewQuery) extends RDD[CouchbaseViewRow](sc, Nil) {
+class ViewRDD(@transient sc: SparkContext, design: String, view: String) extends RDD[CouchbaseViewRow](sc, Nil) {
+  // Use design and view because ViewQuery is not Serializable
 
-  val cbConfig = CouchbaseConfig(sc.getConf)
+  private val cbConfig = CouchbaseConfig(sc.getConf)
 
   override def compute(split: Partition, context: TaskContext): Iterator[CouchbaseViewRow] = {
+    val viewQuery = ViewQuery.from(design, view)
     val bucket = CouchbaseConnection().bucket(cbConfig).async()
 
     toScalaObservable(bucket.query(viewQuery))
@@ -33,18 +32,6 @@ class ViewRDD(sc: SparkContext,viewQuery: ViewQuery) extends RDD[CouchbaseViewRo
 
   override protected def getPartitions: Array[Partition] = Array(new CouchbasePartition(0))
 
-  def documents[D <: Document[_]]()(implicit ct: ClassTag[D]): RDD[D] = {
-    this.mapPartitions { valueIterator =>
-      if (valueIterator.isEmpty) {
-        Iterator[D]()
-      } else {
-        val bucket = CouchbaseConnection().bucket(cbConfig)
-        val castTo = ct.runtimeClass.asInstanceOf[Class[D]]
-        valueIterator
-          .filter(_.id != null)
-          .map[D](row => bucket.get(row.id, castTo))
-      }
-    }
-  }
+  def documents[D <: Document[_]]()(implicit ct: ClassTag[D]): RDD[D] = map(_.id).filter(_ != null).documents
 
 }

--- a/src/test/scala/com/couchbase/spark/Main.scala
+++ b/src/test/scala/com/couchbase/spark/Main.scala
@@ -15,7 +15,14 @@ object Main {
 
     val sc = new SparkContext(conf)
 
+    // Use ids in the codes
+    val docs = sc.couchbaseGet("id")
+    val docs1 = sc.couchbaseGet("id1", "id2")
+    val ids = List("id1", "id2")
+    val docs3 = sc.couchbaseGet(ids: _*)
 
+    // or read ids from files
+    val docs4 = sc.textFile("this_is_a_path").documents
 
     val allDocsStartingWithNameA = sc
       .couchbaseView(ViewQuery.from("beer", "brewery_beers"))


### PR DESCRIPTION
I think DocumentRDD is not necessary. `DocumentRDD` needs a Seq of `ids` to query the docs. However, if the `ids` is large, it should not be a part of  `DocumentRDD` because `DocumentRDD` is a part of task's metadata and it will be sent to all Executors running the tasks in the cluster. So the `ids` should be a RDD[String]. And if the `ids` is small, why use Spark?

Therefore, I create `documents` to convert `RDD[String]` to `RDD[D <: Document[_]]`.