### PR TITLE
Fix some potential issues

### DIFF
--- a/src/main/scala/com/couchbase/spark/DocumentRDDFunctions.scala
+++ b/src/main/scala/com/couchbase/spark/DocumentRDDFunctions.scala
@@ -2,6 +2,7 @@ package com.couchbase.spark
 
 import com.couchbase.client.java.document.Document
 import com.couchbase.spark.connection.{CouchbaseConfig, CouchbaseConnection}
+import com.couchbase.spark.internal.OnceIterable
 import org.apache.spark.rdd.RDD
 import rx.lang.scala.Observable
 import rx.lang.scala.JavaConversions._
@@ -15,7 +16,7 @@ class DocumentRDDFunctions[D <: Document[_]](rdd: RDD[D]) extends Serializable {
       if (iter.nonEmpty) {
         val bucket = CouchbaseConnection().bucket(bucketName, cbConfig).async()
         Observable
-          .from(iter.toIterable)
+          .from(OnceIterable(iter))
           .flatMap(doc => toScalaObservable(bucket.upsert[D](doc)))
           .toBlocking
           .last

--- a/src/main/scala/com/couchbase/spark/RDDFunctions.scala
+++ b/src/main/scala/com/couchbase/spark/RDDFunctions.scala
@@ -21,7 +21,7 @@
  */
 package com.couchbase.spark
 
-import com.couchbase.spark.internal.LazyIterator
+import com.couchbase.spark.internal.{OnceIterable, LazyIterator}
 import rx.lang.scala.JavaConversions._
 import rx.lang.scala.Observable
 
@@ -53,7 +53,7 @@ class RDDFunctions[T](rdd: RDD[T]) extends Serializable {
         val castTo = ct.runtimeClass.asInstanceOf[Class[D]]
         LazyIterator {
           Observable
-            .from(valueIterator.toIterable)
+            .from(OnceIterable(valueIterator))
             .flatMap(id => toScalaObservable(bucket.get(id, castTo)))
             .toBlocking
             .toIterable

--- a/src/main/scala/com/couchbase/spark/RDDFunctions.scala
+++ b/src/main/scala/com/couchbase/spark/RDDFunctions.scala
@@ -21,6 +21,7 @@
  */
 package com.couchbase.spark
 
+import com.couchbase.spark.internal.LazyIterator
 import rx.lang.scala.JavaConversions._
 import rx.lang.scala.Observable
 
@@ -50,12 +51,14 @@ class RDDFunctions[T](rdd: RDD[T]) extends Serializable {
       } else {
         val bucket = CouchbaseConnection().bucket(bucketName, cbConfig).async()
         val castTo = ct.runtimeClass.asInstanceOf[Class[D]]
-        Observable
-          .from(valueIterator.toIterable)
-          .flatMap(id => toScalaObservable(bucket.get(id, castTo)))
-          .toBlocking
-          .toIterable
-          .iterator
+        LazyIterator {
+          Observable
+            .from(valueIterator.toIterable)
+            .flatMap(id => toScalaObservable(bucket.get(id, castTo)))
+            .toBlocking
+            .toIterable
+            .iterator
+        }
       }
     }
   }

--- a/src/main/scala/com/couchbase/spark/internal/LazyIterator.scala
+++ b/src/main/scala/com/couchbase/spark/internal/LazyIterator.scala
@@ -1,0 +1,39 @@
+/**
+ * Copyright (C) 2015 Couchbase, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALING
+ * IN THE SOFTWARE.
+ */
+package com.couchbase.spark.internal
+
+object LazyIterator {
+
+  /**
+   * Return an Iterator that creates `iter` when `hasNext` or `next` is called at the first time.
+   */
+  def apply[T](iter: => Iterator[T]): Iterator[T] = {
+    new Iterator[T] {
+      lazy val delegate = iter
+
+      override def hasNext: Boolean = delegate.hasNext
+
+      override def next(): T = delegate.next()
+    }
+  }
+}
+

--- a/src/main/scala/com/couchbase/spark/internal/OnceIterable.scala
+++ b/src/main/scala/com/couchbase/spark/internal/OnceIterable.scala
@@ -1,0 +1,33 @@
+/**
+ * Copyright (C) 2015 Couchbase, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALING
+ * IN THE SOFTWARE.
+ */
+package com.couchbase.spark.internal
+
+object OnceIterable {
+
+  /**
+   * Return an Iterable that `iterator` will always return `iter`.
+   */
+  def apply[T](iter: Iterator[T]): Iterable[T] = new Iterable[T] {
+    override def iterator: Iterator[T] = iter
+  }
+
+}

--- a/src/main/scala/com/couchbase/spark/rdd/ViewRDD.scala
+++ b/src/main/scala/com/couchbase/spark/rdd/ViewRDD.scala
@@ -23,6 +23,7 @@ package com.couchbase.spark.rdd
 
 import com.couchbase.client.java.view.ViewQuery
 import com.couchbase.spark.connection.{CouchbaseConnection, CouchbaseConfig}
+import com.couchbase.spark.internal.LazyIterator
 import org.apache.spark.{TaskContext, Partition, SparkContext}
 import org.apache.spark.rdd.RDD
 
@@ -38,12 +39,14 @@ class ViewRDD(@transient sc: SparkContext, bucketName: String = null, viewQuery:
   override def compute(split: Partition, context: TaskContext): Iterator[CouchbaseViewRow] = {
     val bucket = CouchbaseConnection().bucket(bucketName, cbConfig).async()
 
-    toScalaObservable(bucket.query(viewQuery))
-      .flatMap(result => toScalaObservable(result.rows()))
-      .map(row => CouchbaseViewRow(row.id(), row.key(), row.value()))
-      .toBlocking
-      .toIterable
-      .iterator
+    LazyIterator {
+      toScalaObservable(bucket.query(viewQuery))
+        .flatMap(result => toScalaObservable(result.rows()))
+        .map(row => CouchbaseViewRow(row.id(), row.key(), row.value()))
+        .toBlocking
+        .toIterable
+        .iterator
+    }
   }
 
   override protected def getPartitions: Array[Partition] = Array(new CouchbasePartition(0))

--- a/src/main/scala/com/couchbase/spark/streaming/DStreamFunctions.scala
+++ b/src/main/scala/com/couchbase/spark/streaming/DStreamFunctions.scala
@@ -1,10 +1,8 @@
 package com.couchbase.spark.streaming
 
 import com.couchbase.client.java.document.Document
-import com.couchbase.spark.connection.{CouchbaseBucket, CouchbaseConnection, CouchbaseConfig}
+import com.couchbase.spark._
 import org.apache.spark.streaming.dstream.DStream
-import rx.lang.scala.JavaConversions._
-import rx.lang.scala.Observable
 
 
 class DStreamFunctions[D <: Document[_]](dstream: DStream[D]) extends Serializable {
@@ -12,21 +10,7 @@ class DStreamFunctions[D <: Document[_]](dstream: DStream[D]) extends Serializab
   def sparkContext = dstream.context.sparkContext
 
   def saveToCouchbase(bucketName: String = null): Unit = {
-    val cbConfig = CouchbaseConfig(sparkContext.getConf)
-
-    dstream.foreachRDD { rdd =>
-      rdd.foreachPartition { iter =>
-        if (iter.nonEmpty) {
-          val bucket = CouchbaseConnection().bucket(bucketName, cbConfig).async()
-          Observable
-            .from(iter.toIterable)
-            .flatMap(doc => toScalaObservable(bucket.upsert[D](doc)))
-            .toBlocking
-            .last
-        }
-      }
-    }
-
+    dstream.foreachRDD(_.saveToCouchbase(bucketName))
   }
 
 

--- a/src/test/scala/com/couchbase/spark/internal/LazyIteratorSpec.scala
+++ b/src/test/scala/com/couchbase/spark/internal/LazyIteratorSpec.scala
@@ -1,0 +1,40 @@
+/**
+ * Copyright (C) 2015 Couchbase, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALING
+ * IN THE SOFTWARE.
+ */
+package com.couchbase.spark.internal
+
+import org.scalatest._
+
+class LazyIteratorSpec extends FlatSpec with Matchers {
+
+  "A LazyIterator" should "not create the delegated Iterator in the constructor" in {
+    var created = false
+    val iter = LazyIterator {
+      created = true
+      Iterator(1, 2, 3)
+    }
+
+    created should equal (false)
+    iter.toList should equal (1 :: 2 :: 3 :: Nil)
+    created should equal (true)
+  }
+
+}


### PR DESCRIPTION
I found some potential issues during reviewing the codes.

1. Scala Iterator.toIterable will cache all values of an Iterator after accessing it, so that it follows the Iterable contract: an Iterable can return an Iterator any time. However, that's not what we want. To avoid caching values, I create an special Iterable that can only be accessed once to avoid OOM.

2. Because RxJava will subscribe when creating Iterator, there may be an OOM issue if Spark doesn't consume the Iterator in time. E.g., when calling rdd1.join(rdd2), Spark will do the following thing:
```
val iters = ListBuffer()
iters.add(rdd1.compute(...))
iters.add(rdd2.compute(...))

while(iters.hasNext()) {
  val i = iters.next()
  process i
}
```
So rdd2's Iterator is created at the beginning, but its content will be consumed only after processing rdd1's Iterator. Considering the time gap may be huge, rdd2's Iterator should not generate data when creating it. Therefore I use LazyIterator to delay it.

In addition, I think DStreamFunctions can call `DocumentRDDFunctions.saveToCouchbase` directly.